### PR TITLE
Use getter operation for latest reading

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -101,8 +101,8 @@ The ProximitySensor Interface {#proximity-sensor-interface}
 <pre class="idl">
   [Constructor(optional SensorOptions sensorOptions), Exposed=Window]
   interface ProximitySensor : Sensor {
-    readonly attribute unrestricted double? distance;
-    readonly attribute unrestricted double? max;
+    readonly attribute double? distance;
+    readonly attribute double? max;
     readonly attribute boolean? near;
   };
 </pre>
@@ -114,26 +114,24 @@ To <dfn>Construct a ProximitySensor Object</dfn> the user agent must invoke the
 ### The distance attribute ### {#proximity-sensor-distance}
 
 The {{ProximitySensor/distance!!attribute}} attribute of the {{ProximitySensor}}
-interface represents the [=distance=] value.
-In other words, this attribute returns [=latest reading=]["distance"].
+interface returns the result of invoking [=get value from latest reading=] with
+<emu-val>this</emu-val> and "distance" as arguments.
 
 ### The max attribute ### {#proximity-sensor-max}
 
 The {{ProximitySensor/max!!attribute}} attribute of the {{ProximitySensor}}
-interface represents the [=max=] value.
-In other words, this attribute returns [=latest reading=]["max"].
+interface returns the result of invoking [=get value from latest reading=] with
+<emu-val>this</emu-val> and "max" as arguments.
 
 ### The near attribute ### {#proximity-sensor-near}
 
 The {{ProximitySensor/near!!attribute}} attribute of the {{ProximitySensor}}
-interface represents the [=near=] value.
-In other words, this attribute returns [=latest reading=]["near"].
+interface returns the result of invoking [=get value from latest reading=] with
+<emu-val>this</emu-val> and "near" as arguments.
 
-
-Note: If the implementation is unable to provide the [=near=] value, it could infer the [=near=] value from the value of [=distance=].
-For example, if [=distance=] is not equal to [=max=] or default value (Infinity),
-it could imply there is an object in the sensing range.
-
+Note: If the implementation is unable to provide the [=near=] value, it could infer the [=near=]
+value from the value of [=distance=]. For example, if [=distance=] is not equal to [=max=], it
+could imply there is an object in the sensing range.
 
 Limitations of Proximity Sensors {#limitations-proximity-sensors}
 ========================

--- a/index.html
+++ b/index.html
@@ -1183,9 +1183,8 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version df778ba2d9793f77f64705dbba65d0c50f68e0d9" name="generator">
+  <meta content="Bikeshed version eeaa009c31ac13852bf86c1553d994e53f48f852" name="generator">
   <link href="https://www.w3.org/TR/proximity/" rel="canonical">
-  <meta content="2a4126392b584790f3a66106bca24f4cd3e6401f" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1432,7 +1431,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Proximity Sensor</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-09-21">21 September 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-09-25">25 September 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1536,14 +1535,14 @@ method, sensor construction, etc.  Moreover some proximity sensors might be only
 able to provide just a boolean to indicate if there is an object which is near,
 more like presence detection, than an absolute value for the distance.</p>
    <h2 class="heading settled" data-level="2" id="examples"><span class="secno">2. </span><span class="content">Examples</span><a class="self-link" href="#examples"></a></h2>
-   <div class="example" id="example-05d81306">
-    <a class="self-link" href="#example-05d81306"></a> 
+   <div class="example" id="example-fbf52dff">
+    <a class="self-link" href="#example-fbf52dff"></a> 
 <pre class="highlight"><span class="kd">let</span> sensor <span class="o">=</span> <span class="k">new</span> ProximitySensor<span class="p">();</span>
 sensor<span class="p">.</span>start<span class="p">();</span>
 
-sensor<span class="p">.</span>onreading <span class="o">=</span> <span class="p">()</span> <span class="o">=></span> console<span class="p">.</span>log<span class="p">(</span>sensor<span class="p">.</span>distance<span class="p">);</span>
+sensor<span class="p">.</span>onreading <span class="o">=</span> <span class="p">()</span> <span class="p">=></span> console<span class="p">.</span>log<span class="p">(</span>sensor<span class="p">.</span>distance<span class="p">);</span>
 
-sensor<span class="p">.</span>onerror <span class="o">=</span> event <span class="o">=></span> console<span class="p">.</span>log<span class="p">(</span>event<span class="p">.</span>error<span class="p">.</span>name<span class="p">,</span> event<span class="p">.</span>error<span class="p">.</span>message<span class="p">);</span>
+sensor<span class="p">.</span>onerror <span class="o">=</span> event <span class="p">=></span> console<span class="p">.</span>log<span class="p">(</span>event<span class="p">.</span>error<span class="p">.</span>name<span class="p">,</span> event<span class="p">.</span>error<span class="p">.</span>message<span class="p">);</span>
 </pre>
    </div>
    <h2 class="heading settled" data-level="3" id="security-and-privacy"><span class="secno">3. </span><span class="content">Security and Privacy Considerations</span><a class="self-link" href="#security-and-privacy"></a></h2>
@@ -1564,24 +1563,20 @@ in the vicinity of the main proximity detector.</p>
    <h3 class="heading settled" data-level="5.1" id="proximity-sensor-interface"><span class="secno">5.1. </span><span class="content">The ProximitySensor Interface</span><a class="self-link" href="#proximity-sensor-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="ProximitySensor" data-dfn-type="constructor" data-export="" data-lt="ProximitySensor(sensorOptions)|ProximitySensor()" id="dom-proximitysensor-proximitysensor"><code>Constructor</code><a class="self-link" href="#dom-proximitysensor-proximitysensor"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions">SensorOptions</a> <dfn class="nv idl-code" data-dfn-for="ProximitySensor/ProximitySensor(sensorOptions)" data-dfn-type="argument" data-export="" id="dom-proximitysensor-proximitysensor-sensoroptions-sensoroptions"><code>sensorOptions</code><a class="self-link" href="#dom-proximitysensor-proximitysensor-sensoroptions-sensoroptions"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed">Exposed</a>=<span class="n">Window</span>]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="proximitysensor"><code>ProximitySensor</code></dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor②">Sensor</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double" id="ref-for-idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="ProximitySensor" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-proximitysensor-distance"><code>distance</code></dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double" id="ref-for-idl-unrestricted-double①"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="ProximitySensor" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-proximitysensor-max"><code>max</code></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double"><span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="ProximitySensor" data-dfn-type="attribute" data-export="" data-readonly="" data-type="double?" id="dom-proximitysensor-distance"><code>distance</code></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①"><span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="ProximitySensor" data-dfn-type="attribute" data-export="" data-readonly="" data-type="double?" id="dom-proximitysensor-max"><code>max</code></dfn>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean"><span class="kt">boolean</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="ProximitySensor" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean?" id="dom-proximitysensor-near"><code>near</code></dfn>;
 };
 </pre>
    <p>To <dfn data-dfn-type="dfn" data-noexport="" id="construct-a-proximitysensor-object">Construct a ProximitySensor Object<a class="self-link" href="#construct-a-proximitysensor-object"></a></dfn> the user agent must invoke the <a data-link-type="dfn" href="https://w3c.github.io/sensors#construct-sensor-object" id="ref-for-construct-sensor-object">construct a Sensor object</a> abstract operation.</p>
    <h4 class="heading settled" data-level="5.1.1" id="proximity-sensor-distance"><span class="secno">5.1.1. </span><span class="content">The distance attribute</span><a class="self-link" href="#proximity-sensor-distance"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-proximitysensor-distance" id="ref-for-dom-proximitysensor-distance">distance</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#proximitysensor" id="ref-for-proximitysensor①">ProximitySensor</a></code> interface represents the <a data-link-type="dfn" href="#distance" id="ref-for-distance①">distance</a> value.
-In other words, this attribute returns <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading" id="ref-for-latest-reading①">latest reading</a>["distance"].</p>
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-proximitysensor-distance" id="ref-for-dom-proximitysensor-distance">distance</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#proximitysensor" id="ref-for-proximitysensor①">ProximitySensor</a></code> interface returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading">get value from latest reading</a> with <emu-val>this</emu-val> and "distance" as arguments.</p>
    <h4 class="heading settled" data-level="5.1.2" id="proximity-sensor-max"><span class="secno">5.1.2. </span><span class="content">The max attribute</span><a class="self-link" href="#proximity-sensor-max"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-proximitysensor-max" id="ref-for-dom-proximitysensor-max">max</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#proximitysensor" id="ref-for-proximitysensor②">ProximitySensor</a></code> interface represents the <a data-link-type="dfn" href="#max" id="ref-for-max①">max</a> value.
-In other words, this attribute returns <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading" id="ref-for-latest-reading②">latest reading</a>["max"].</p>
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-proximitysensor-max" id="ref-for-dom-proximitysensor-max">max</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#proximitysensor" id="ref-for-proximitysensor②">ProximitySensor</a></code> interface returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading①">get value from latest reading</a> with <emu-val>this</emu-val> and "max" as arguments.</p>
    <h4 class="heading settled" data-level="5.1.3" id="proximity-sensor-near"><span class="secno">5.1.3. </span><span class="content">The near attribute</span><a class="self-link" href="#proximity-sensor-near"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-proximitysensor-near" id="ref-for-dom-proximitysensor-near">near</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#proximitysensor" id="ref-for-proximitysensor③">ProximitySensor</a></code> interface represents the <a data-link-type="dfn" href="#near" id="ref-for-near①">near</a> value.
-In other words, this attribute returns <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading" id="ref-for-latest-reading③">latest reading</a>["near"].</p>
-   <p class="note" role="note"><span>Note:</span> If the implementation is unable to provide the <a data-link-type="dfn" href="#near" id="ref-for-near②">near</a> value, it could infer the <a data-link-type="dfn" href="#near" id="ref-for-near③">near</a> value from the value of <a data-link-type="dfn" href="#distance" id="ref-for-distance②">distance</a>.
-For example, if <a data-link-type="dfn" href="#distance" id="ref-for-distance③">distance</a> is not equal to <a data-link-type="dfn" href="#max" id="ref-for-max②">max</a> or default value (Infinity),
-it could imply there is an object in the sensing range.</p>
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-proximitysensor-near" id="ref-for-dom-proximitysensor-near">near</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#proximitysensor" id="ref-for-proximitysensor③">ProximitySensor</a></code> interface returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading②">get value from latest reading</a> with <emu-val>this</emu-val> and "near" as arguments.</p>
+   <p class="note" role="note"><span>Note:</span> If the implementation is unable to provide the <a data-link-type="dfn" href="#near" id="ref-for-near①">near</a> value, it could infer the <a data-link-type="dfn" href="#near" id="ref-for-near②">near</a> value from the value of <a data-link-type="dfn" href="#distance" id="ref-for-distance①">distance</a>. For example, if <a data-link-type="dfn" href="#distance" id="ref-for-distance②">distance</a> is not equal to <a data-link-type="dfn" href="#max" id="ref-for-max①">max</a>, it
+could imply there is an object in the sensing range.</p>
    <h2 class="heading settled" data-level="6" id="limitations-proximity-sensors"><span class="secno">6. </span><span class="content">Limitations of Proximity Sensors</span><a class="self-link" href="#limitations-proximity-sensors"></a></h2>
    <p>Since most proximity sensors detect electromagnetic radiation (e.g., an infrared light
 or a magnetic field), certain material properties can interfere with the sensor’s
@@ -1656,6 +1651,7 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <ul>
      <li><a href="https://w3c.github.io/sensors/#sensor">Sensor</a>
      <li><a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a>
+     <li><a href="https://w3c.github.io/sensors/#get-value-from-latest-reading">get value from latest reading</a>
     </ul>
    <li>
     <a data-link-type="biblio">[INFRA]</a> defines the following terms:
@@ -1669,7 +1665,7 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <ul>
      <li><a href="https://heycam.github.io/webidl/#Exposed">Exposed</a>
      <li><a href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>
-     <li><a href="https://heycam.github.io/webidl/#idl-unrestricted-double">unrestricted double</a>
+     <li><a href="https://heycam.github.io/webidl/#idl-double">double</a>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
@@ -1687,8 +1683,8 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
 <pre class="idl highlight def">[<a class="nv" href="#dom-proximitysensor-proximitysensor"><code>Constructor</code></a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions①">SensorOptions</a> <a class="nv" href="#dom-proximitysensor-proximitysensor-sensoroptions-sensoroptions"><code>sensorOptions</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①">Exposed</a>=<span class="n">Window</span>]
 <span class="kt">interface</span> <a class="nv" href="#proximitysensor"><code>ProximitySensor</code></a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor②①">Sensor</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double" id="ref-for-idl-unrestricted-double②"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-proximitysensor-distance"><code>distance</code></a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double" id="ref-for-idl-unrestricted-double①①"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-proximitysensor-max"><code>max</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②"><span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="double?" href="#dom-proximitysensor-distance"><code>distance</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①①"><span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="double?" href="#dom-proximitysensor-max"><code>max</code></a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①"><span class="kt">boolean</span></a>? <a class="nv" data-readonly="" data-type="boolean?" href="#dom-proximitysensor-near"><code>near</code></a>;
 };
 
@@ -1703,23 +1699,21 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <b><a href="#distance">#distance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-distance">4. Model</a>
-    <li><a href="#ref-for-distance①">5.1.1. The distance attribute</a>
-    <li><a href="#ref-for-distance②">5.1.3. The near attribute</a> <a href="#ref-for-distance③">(2)</a>
+    <li><a href="#ref-for-distance①">5.1.3. The near attribute</a> <a href="#ref-for-distance②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="max">
    <b><a href="#max">#max</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max">4. Model</a>
-    <li><a href="#ref-for-max①">5.1.2. The max attribute</a>
-    <li><a href="#ref-for-max②">5.1.3. The near attribute</a>
+    <li><a href="#ref-for-max①">5.1.3. The near attribute</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="near">
    <b><a href="#near">#near</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-near">4. Model</a>
-    <li><a href="#ref-for-near①">5.1.3. The near attribute</a> <a href="#ref-for-near②">(2)</a> <a href="#ref-for-near③">(3)</a>
+    <li><a href="#ref-for-near①">5.1.3. The near attribute</a> <a href="#ref-for-near②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="proximitysensor">


### PR DESCRIPTION
- Use proper getter operation
- Remove usage of unrestricted doubles


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/alexshalamov/proximity/use_proper_getter.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/proximity/25206d2...alexshalamov:b204353.html)