### PR TITLE
Integration of mock sensor type

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -39,6 +39,9 @@ urlPrefix: https://w3c.github.io/sensors; spec: GENERIC-SENSOR
     text: fingerprinting; url: device-fingerprinting
     text: user identifying; url: user-identifying
     text: mitigation strategies; url: mitigation-strategies
+    text: automation
+    text: mock sensor type
+    text: mock sensor reading values
 </pre>
 <pre class="link-defaults">
 spec:infra;
@@ -184,6 +187,26 @@ Abstract Operations {#abstract-operations}
     1.  Invoke [=initialize a sensor object=] with |proximity_sensor| and |options|.
     1.  Return |proximity_sensor|.
 </div>
+
+Automation {#automation}
+==========
+This section extends the [=automation=] section defined in the Generic Sensor API [[GENERIC-SENSOR]]
+to provide mocking information about the proximity level for the purposes of
+testing a user agent's implementation of {{ProximitySensor}} API.
+
+<h3 id="mock-proximity-sensor-type">Mock Sensor Type</h3>
+
+The {{ProximitySensor}} class has an associated [=mock sensor type=] which is
+<a for="MockSensorType" enum-value>"proximity"</a>, its [=mock sensor reading values=]
+dictionary is defined as follow:
+
+<pre class="idl">
+  dictionary ProximityReadingValues {
+    required double? distance;
+    required double? max;
+    required boolean? near;
+  };
+</pre>
 
 Limitations of Proximity Sensors {#limitations-proximity-sensors}
 ========================

--- a/index.bs
+++ b/index.bs
@@ -198,7 +198,7 @@ testing a user agent's implementation of {{ProximitySensor}} API.
 
 The {{ProximitySensor}} class has an associated [=mock sensor type=] which is
 <a for="MockSensorType" enum-value>"proximity"</a>, its [=mock sensor reading values=]
-dictionary is defined as follow:
+dictionary is defined as follows:
 
 <pre class="idl">
   dictionary ProximityReadingValues {

--- a/index.html
+++ b/index.html
@@ -1221,7 +1221,7 @@ Possible extra rowspan handling
   </style>
   <meta content="Bikeshed version 9c6ae748322940994300e90a77c34437364b40a6" name="generator">
   <link href="https://www.w3.org/TR/proximity/" rel="canonical">
-  <meta content="41e9f044b443a800c39da8876d5d16054ac70080" name="document-revision">
+  <meta content="658f5b6853195e6df9b9bfa00fcd38464f821f33" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1678,7 +1678,7 @@ could imply there is a physical object in the <a data-link-type="dfn" href="#sen
     This section extends the <a data-link-type="dfn" href="https://w3c.github.io/sensors#automation" id="ref-for-automation">automation</a> section defined in the Generic Sensor API <a data-link-type="biblio" href="#biblio-generic-sensor">[GENERIC-SENSOR]</a> to provide mocking information about the proximity level for the purposes of
 testing a user agent’s implementation of <code class="idl"><a data-link-type="idl" href="#proximitysensor" id="ref-for-proximitysensor⑧">ProximitySensor</a></code> API. 
    <h3 class="heading settled" data-level="7.1" id="mock-proximity-sensor-type"><span class="secno">7.1. </span><span class="content">Mock Sensor Type</span><a class="self-link" href="#mock-proximity-sensor-type"></a></h3>
-   <p>The <code class="idl"><a data-link-type="idl" href="#proximitysensor" id="ref-for-proximitysensor⑨">ProximitySensor</a></code> class has an associated <a data-link-type="dfn" href="https://w3c.github.io/sensors#mock-sensor-type" id="ref-for-mock-sensor-type">mock sensor type</a> which is <a class="idl-code" data-link-type="enum-value">"proximity"</a>, its <a data-link-type="dfn" href="https://w3c.github.io/sensors#mock-sensor-reading-values" id="ref-for-mock-sensor-reading-values">mock sensor reading values</a> dictionary is defined as follow:</p>
+   <p>The <code class="idl"><a data-link-type="idl" href="#proximitysensor" id="ref-for-proximitysensor⑨">ProximitySensor</a></code> class has an associated <a data-link-type="dfn" href="https://w3c.github.io/sensors#mock-sensor-type" id="ref-for-mock-sensor-type">mock sensor type</a> which is <a class="idl-code" data-link-type="enum-value">"proximity"</a>, its <a data-link-type="dfn" href="https://w3c.github.io/sensors#mock-sensor-reading-values" id="ref-for-mock-sensor-reading-values">mock sensor reading values</a> dictionary is defined as follows:</p>
 <pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="idl-code" data-dfn-type="dictionary" data-export id="dictdef-proximityreadingvalues"><code><c- g>ProximityReadingValues</c-></code><a class="self-link" href="#dictdef-proximityreadingvalues"></a></dfn> {
   <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="ProximityReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-proximityreadingvalues-distance"><code><c- g>distance</c-></code><a class="self-link" href="#dom-proximityreadingvalues-distance"></a></dfn>;
   <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double③"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="ProximityReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-proximityreadingvalues-max"><code><c- g>max</c-></code><a class="self-link" href="#dom-proximityreadingvalues-max"></a></dfn>;

--- a/index.html
+++ b/index.html
@@ -993,57 +993,93 @@ Possible extra rowspan handling
 	.toc > li li          { font-weight: normal; }
 	.toc > li li li       { font-size:   95%;    }
 	.toc > li li li li    { font-size:   90%;    }
+	.toc > li li li li .secno { font-size: 85%; }
 	.toc > li li li li li { font-size:   85%;    }
+	.toc > li li li li li .secno { font-size: 100%; }
 
-	.toc > li             { margin: 1.5rem 0;    }
-	.toc > li li          { margin: 0.3rem 0;    }
-	.toc > li li li       { margin-left: 2rem;   }
+	/* @supports not (display:grid) { */
+		.toc > li             { margin: 1.5rem 0;    }
+		.toc > li li          { margin: 0.3rem 0;    }
+		.toc > li li li       { margin-left: 2rem;   }
 
-	/* Section numbers in a column of their own */
-	.toc .secno {
-		float: left;
-		width: 4rem;
-		white-space: nowrap;
-	}
-	.toc > li li li li .secno {
-		font-size: 85%;
-	}
-	.toc > li li li li li .secno {
-		font-size: 100%;
-	}
+		/* Section numbers in a column of their own */
+		.toc .secno {
+			float: left;
+			width: 4rem;
+			white-space: nowrap;
+		}
 
-	:not(li) > .toc              { margin-left:  5rem; }
-	.toc .secno                  { margin-left: -5rem; }
-	.toc > li li li .secno       { margin-left: -7rem; }
-	.toc > li li li li .secno    { margin-left: -9rem; }
-	.toc > li li li li li .secno { margin-left: -11rem; }
+		.toc li {
+			clear: both;
+		}
 
-	/* Tighten up indentation in narrow ToCs */
-	@media (max-width: 30em) {
-		:not(li) > .toc              { margin-left:  4rem; }
-		.toc .secno                  { margin-left: -4rem; }
-		.toc > li li li              { margin-left:  1rem; }
-		.toc > li li li .secno       { margin-left: -5rem; }
-		.toc > li li li li .secno    { margin-left: -6rem; }
-		.toc > li li li li li .secno { margin-left: -7rem; }
-	}
-	@media screen and (min-width: 78em) {
-		body:not(.toc-inline) :not(li) > .toc              { margin-left:  4rem; }
-		body:not(.toc-inline) .toc .secno                  { margin-left: -4rem; }
-		body:not(.toc-inline) .toc > li li li              { margin-left:  1rem; }
-		body:not(.toc-inline) .toc > li li li .secno       { margin-left: -5rem; }
-		body:not(.toc-inline) .toc > li li li li .secno    { margin-left: -6rem; }
-		body:not(.toc-inline) .toc > li li li li li .secno { margin-left: -7rem; }
-	}
-	body.toc-sidebar #toc :not(li) > .toc              { margin-left:  4rem; }
-	body.toc-sidebar #toc .toc .secno                  { margin-left: -4rem; }
-	body.toc-sidebar #toc .toc > li li li              { margin-left:  1rem; }
-	body.toc-sidebar #toc .toc > li li li .secno       { margin-left: -5rem; }
-	body.toc-sidebar #toc .toc > li li li li .secno    { margin-left: -6rem; }
-	body.toc-sidebar #toc .toc > li li li li li .secno { margin-left: -7rem; }
+		:not(li) > .toc              { margin-left:  5rem; }
+		.toc .secno                  { margin-left: -5rem; }
+		.toc > li li li .secno       { margin-left: -7rem; }
+		.toc > li li li li .secno    { margin-left: -9rem; }
+		.toc > li li li li li .secno { margin-left: -11rem; }
 
-	.toc li {
-		clear: both;
+		/* Tighten up indentation in narrow ToCs */
+		@media (max-width: 30em) {
+			:not(li) > .toc              { margin-left:  4rem; }
+			.toc .secno                  { margin-left: -4rem; }
+			.toc > li li li              { margin-left:  1rem; }
+			.toc > li li li .secno       { margin-left: -5rem; }
+			.toc > li li li li .secno    { margin-left: -6rem; }
+			.toc > li li li li li .secno { margin-left: -7rem; }
+		}
+	/* } */
+
+	@supports (display:grid) {
+		/* Use #toc over .toc to override non-@supports rules. */
+		#toc {
+			display: grid;
+			align-content: start;
+			grid-template-columns: auto 1fr;
+			grid-column-gap: 1rem;
+			column-gap: 1rem;
+			grid-row-gap: .6rem;
+			row-gap: .6rem;
+		}
+		#toc h2 {
+			grid-column: 1 / -1;
+			margin-bottom: 0;
+		}
+		#toc ol,
+		#toc li,
+		#toc a {
+			display: contents;
+			/* Switch <a> to subgrid when supported */
+		}
+		#toc span {
+			margin: 0;
+		}
+		#toc > .toc > li > a > span {
+			/* The spans of the top-level list,
+			   comprising the first items of each top-level section. */
+			margin-top: 1.1rem;
+		}
+		#toc#toc .secno { /* Ugh, need more specificity to override base.css */
+			grid-column: 1;
+			width: auto;
+			margin-left: 0;
+		}
+		#toc .content {
+			grid-column: 2;
+			width: auto;
+			margin-right: 1rem;
+		}
+		#toc .content:hover {
+			background: rgba(75%, 75%, 75%, .25);
+			border-bottom: 3px solid #054572;
+			margin-bottom: -3px;
+		}
+		#toc li li li .content {
+			margin-left: 1rem;
+		}
+		#toc li li li li .content {
+			margin-left: 2rem;
+		}
 	}
 
 
@@ -1183,8 +1219,9 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version 66a76cd06d4fa9e491630583356008a71a166760" name="generator">
+  <meta content="Bikeshed version 9c6ae748322940994300e90a77c34437364b40a6" name="generator">
   <link href="https://www.w3.org/TR/proximity/" rel="canonical">
+  <meta content="41e9f044b443a800c39da8876d5d16054ac70080" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1270,6 +1307,17 @@ figcaption {
 figcaption:not(.no-marker)::before {
     content: "Figure " counter(figure) " ";
 }</style>
+<style>/* style-var-click-highlighting */
+
+    var { cursor: pointer; }
+    var.selected0 { background-color: #F4D200; box-shadow: 0 0 0 2px #F4D200; }
+    var.selected1 { background-color: #FF87A2; box-shadow: 0 0 0 2px #FF87A2; }
+    var.selected2 { background-color: #96E885; box-shadow: 0 0 0 2px #96E885; }
+    var.selected3 { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEED2; }
+    var.selected4 { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
+    var.selected5 { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
+    var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+    </style>
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -1334,104 +1382,104 @@ pre .property::before, pre .property::after {
 }</style>
 <style>/* style-dfn-panel */
 
-        .dfn-panel {
-            position: absolute;
-            z-index: 35;
-            height: auto;
-            width: -webkit-fit-content;
-            width: fit-content;
-            max-width: 300px;
-            max-height: 500px;
-            overflow: auto;
-            padding: 0.5em 0.75em;
-            font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
-            background: #DDDDDD;
-            color: black;
-            border: outset 0.2em;
-        }
-        .dfn-panel:not(.on) { display: none; }
-        .dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
-        .dfn-panel > b { display: block; }
-        .dfn-panel a { color: black; }
-        .dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
-        .dfn-panel > b + b { margin-top: 0.25em; }
-        .dfn-panel ul { padding: 0; }
-        .dfn-panel li { list-style: inside; }
-        .dfn-panel.activated {
-            display: inline-block;
-            position: fixed;
-            left: .5em;
-            bottom: 2em;
-            margin: 0 auto;
-            max-width: calc(100vw - 1.5em - .4em - .5em);
-            max-height: 30vh;
-        }
+.dfn-panel {
+    position: absolute;
+    z-index: 35;
+    height: auto;
+    width: -webkit-fit-content;
+    width: fit-content;
+    max-width: 300px;
+    max-height: 500px;
+    overflow: auto;
+    padding: 0.5em 0.75em;
+    font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
+    background: #DDDDDD;
+    color: black;
+    border: outset 0.2em;
+}
+.dfn-panel:not(.on) { display: none; }
+.dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
+.dfn-panel > b { display: block; }
+.dfn-panel a { color: black; }
+.dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
+.dfn-panel > b + b { margin-top: 0.25em; }
+.dfn-panel ul { padding: 0; }
+.dfn-panel li { list-style: inside; }
+.dfn-panel.activated {
+    display: inline-block;
+    position: fixed;
+    left: .5em;
+    bottom: 2em;
+    margin: 0 auto;
+    max-width: calc(100vw - 1.5em - .4em - .5em);
+    max-height: 30vh;
+}
 
-        .dfn-paneled { cursor: pointer; }
-        </style>
+.dfn-paneled { cursor: pointer; }
+</style>
 <style>/* style-syntax-highlighting */
 pre.idl.highlight { color: #708090; }
 .highlight:not(.idl) { background: hsl(24, 20%, 95%); }
 code.highlight { padding: .1em; border-radius: .3em; }
 pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
-.highlight .c { color: #708090 } /* Comment */
-.highlight .k { color: #990055 } /* Keyword */
-.highlight .l { color: #000000 } /* Literal */
-.highlight .n { color: #0077aa } /* Name */
-.highlight .o { color: #999999 } /* Operator */
-.highlight .p { color: #999999 } /* Punctuation */
-.highlight .cm { color: #708090 } /* Comment.Multiline */
-.highlight .cp { color: #708090 } /* Comment.Preproc */
-.highlight .c1 { color: #708090 } /* Comment.Single */
-.highlight .cs { color: #708090 } /* Comment.Special */
-.highlight .kc { color: #990055 } /* Keyword.Constant */
-.highlight .kd { color: #990055 } /* Keyword.Declaration */
-.highlight .kn { color: #990055 } /* Keyword.Namespace */
-.highlight .kp { color: #990055 } /* Keyword.Pseudo */
-.highlight .kr { color: #990055 } /* Keyword.Reserved */
-.highlight .kt { color: #990055 } /* Keyword.Type */
-.highlight .ld { color: #000000 } /* Literal.Date */
-.highlight .m { color: #000000 } /* Literal.Number */
-.highlight .s { color: #a67f59 } /* Literal.String */
-.highlight .na { color: #0077aa } /* Name.Attribute */
-.highlight .nc { color: #0077aa } /* Name.Class */
-.highlight .no { color: #0077aa } /* Name.Constant */
-.highlight .nd { color: #0077aa } /* Name.Decorator */
-.highlight .ni { color: #0077aa } /* Name.Entity */
-.highlight .ne { color: #0077aa } /* Name.Exception */
-.highlight .nf { color: #0077aa } /* Name.Function */
-.highlight .nl { color: #0077aa } /* Name.Label */
-.highlight .nn { color: #0077aa } /* Name.Namespace */
-.highlight .py { color: #0077aa } /* Name.Property */
-.highlight .nt { color: #669900 } /* Name.Tag */
-.highlight .nv { color: #222222 } /* Name.Variable */
-.highlight .ow { color: #999999 } /* Operator.Word */
-.highlight .mb { color: #000000 } /* Literal.Number.Bin */
-.highlight .mf { color: #000000 } /* Literal.Number.Float */
-.highlight .mh { color: #000000 } /* Literal.Number.Hex */
-.highlight .mi { color: #000000 } /* Literal.Number.Integer */
-.highlight .mo { color: #000000 } /* Literal.Number.Oct */
-.highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
-.highlight .sc { color: #a67f59 } /* Literal.String.Char */
-.highlight .sd { color: #a67f59 } /* Literal.String.Doc */
-.highlight .s2 { color: #a67f59 } /* Literal.String.Double */
-.highlight .se { color: #a67f59 } /* Literal.String.Escape */
-.highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
-.highlight .si { color: #a67f59 } /* Literal.String.Interpol */
-.highlight .sx { color: #a67f59 } /* Literal.String.Other */
-.highlight .sr { color: #a67f59 } /* Literal.String.Regex */
-.highlight .s1 { color: #a67f59 } /* Literal.String.Single */
-.highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
-.highlight .vc { color: #0077aa } /* Name.Variable.Class */
-.highlight .vg { color: #0077aa } /* Name.Variable.Global */
-.highlight .vi { color: #0077aa } /* Name.Variable.Instance */
-.highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
+c-[a] { color: #990055 } /* Keyword.Declaration */
+c-[b] { color: #990055 } /* Keyword.Type */
+c-[c] { color: #708090 } /* Comment */
+c-[d] { color: #708090 } /* Comment.Multiline */
+c-[e] { color: #0077aa } /* Name.Attribute */
+c-[f] { color: #669900 } /* Name.Tag */
+c-[g] { color: #222222 } /* Name.Variable */
+c-[k] { color: #990055 } /* Keyword */
+c-[l] { color: #000000 } /* Literal */
+c-[m] { color: #000000 } /* Literal.Number */
+c-[n] { color: #0077aa } /* Name */
+c-[o] { color: #999999 } /* Operator */
+c-[p] { color: #999999 } /* Punctuation */
+c-[s] { color: #a67f59 } /* Literal.String */
+c-[t] { color: #a67f59 } /* Literal.String.Single */
+c-[u] { color: #a67f59 } /* Literal.String.Double */
+c-[cp] { color: #708090 } /* Comment.Preproc */
+c-[c1] { color: #708090 } /* Comment.Single */
+c-[cs] { color: #708090 } /* Comment.Special */
+c-[kc] { color: #990055 } /* Keyword.Constant */
+c-[kn] { color: #990055 } /* Keyword.Namespace */
+c-[kp] { color: #990055 } /* Keyword.Pseudo */
+c-[kr] { color: #990055 } /* Keyword.Reserved */
+c-[ld] { color: #000000 } /* Literal.Date */
+c-[nc] { color: #0077aa } /* Name.Class */
+c-[no] { color: #0077aa } /* Name.Constant */
+c-[nd] { color: #0077aa } /* Name.Decorator */
+c-[ni] { color: #0077aa } /* Name.Entity */
+c-[ne] { color: #0077aa } /* Name.Exception */
+c-[nf] { color: #0077aa } /* Name.Function */
+c-[nl] { color: #0077aa } /* Name.Label */
+c-[nn] { color: #0077aa } /* Name.Namespace */
+c-[py] { color: #0077aa } /* Name.Property */
+c-[ow] { color: #999999 } /* Operator.Word */
+c-[mb] { color: #000000 } /* Literal.Number.Bin */
+c-[mf] { color: #000000 } /* Literal.Number.Float */
+c-[mh] { color: #000000 } /* Literal.Number.Hex */
+c-[mi] { color: #000000 } /* Literal.Number.Integer */
+c-[mo] { color: #000000 } /* Literal.Number.Oct */
+c-[sb] { color: #a67f59 } /* Literal.String.Backtick */
+c-[sc] { color: #a67f59 } /* Literal.String.Char */
+c-[sd] { color: #a67f59 } /* Literal.String.Doc */
+c-[se] { color: #a67f59 } /* Literal.String.Escape */
+c-[sh] { color: #a67f59 } /* Literal.String.Heredoc */
+c-[si] { color: #a67f59 } /* Literal.String.Interpol */
+c-[sx] { color: #a67f59 } /* Literal.String.Other */
+c-[sr] { color: #a67f59 } /* Literal.String.Regex */
+c-[ss] { color: #a67f59 } /* Literal.String.Symbol */
+c-[vc] { color: #0077aa } /* Name.Variable.Class */
+c-[vg] { color: #0077aa } /* Name.Variable.Global */
+c-[vi] { color: #0077aa } /* Name.Variable.Instance */
+c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 </style>
  <body class="h-entry">
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Proximity Sensor</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-03-01">1 March 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-01-28">28 January 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1443,7 +1491,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
      <dt>Version History:
      <dd><a href="https://github.com/w3c/proximity/commits/gh-pages/index.bs">https://github.com/w3c/proximity/commits/gh-pages/index.bs</a>
      <dt>Feedback:
-     <dd><span><a href="mailto:public-device-apis@w3.org?subject=%5Bproximity%5D%20YOUR%20TOPIC%20HERE">public-device-apis@w3.org</a> with subject line “<kbd>[proximity] <i data-lt="">… message topic …</i></kbd>” (<a href="https://lists.w3.org/Archives/Public/public-device-apis/" rel="discussion">archives</a>)</span>
+     <dd><span><a href="mailto:public-device-apis@w3.org?subject=%5Bproximity%5D%20YOUR%20TOPIC%20HERE">public-device-apis@w3.org</a> with subject line “<kbd>[proximity] <i data-lt>… message topic …</i></kbd>” (<a href="https://lists.w3.org/Archives/Public/public-device-apis/" rel="discussion">archives</a>)</span>
      <dt>Issue Tracking:
      <dd><a href="https://github.com/w3c/proximity/issues/">GitHub</a>
      <dd><a href="https://github.com/w3c/proximity/issues">Issues</a>
@@ -1459,14 +1507,14 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2018 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2019 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <div class="p-summary" data-fill-with="abstract">
    <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
    <p>This specification defines a concrete sensor interface to monitor
 
-the presence of nearby physical objects without physical contact.</p>
+  the presence of nearby physical objects without physical contact.</p>
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="sotd"><span class="content">Status of this document</span></h2>
   <div data-fill-with="status">
@@ -1480,7 +1528,7 @@ the presence of nearby physical objects without physical contact.</p>
 	preferably like this:
 	“[proximity] <em>…summary of comment…</em>”.
 	All comments are welcome. </p>
-   <p> This document was produced by the <a href="https://www.w3.org/2009/dap/">Device and Sensors Working Group</a>. </p>
+   <p> This document was produced by the <a href="https://www.w3.org/das/">Devices and Sensors Working Group</a>. </p>
    <p> This document was produced by a group operating under
 	the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
 	W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/43696/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
@@ -1513,9 +1561,14 @@ the presence of nearby physical objects without physical contact.</p>
      <ol class="toc">
       <li><a href="#construct-a-proximity-sensor-object"><span class="secno">6.1</span> <span class="content">Construct a proximity sensor object</span></a>
      </ol>
-    <li><a href="#limitations-proximity-sensors"><span class="secno">7</span> <span class="content">Limitations of Proximity Sensors</span></a>
-    <li><a href="#acknowledgements"><span class="secno">8</span> <span class="content">Acknowledgements</span></a>
-    <li><a href="#conformance"><span class="secno">9</span> <span class="content">Conformance</span></a>
+    <li>
+     <a href="#automation"><span class="secno">7</span> <span class="content">Automation</span></a>
+     <ol class="toc">
+      <li><a href="#mock-proximity-sensor-type"><span class="secno">7.1</span> <span class="content">Mock Sensor Type</span></a>
+     </ol>
+    <li><a href="#limitations-proximity-sensors"><span class="secno">8</span> <span class="content">Limitations of Proximity Sensors</span></a>
+    <li><a href="#acknowledgements"><span class="secno">9</span> <span class="content">Acknowledgements</span></a>
+    <li><a href="#conformance"><span class="secno">10</span> <span class="content">Conformance</span></a>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
@@ -1534,20 +1587,20 @@ the presence of nearby physical objects without physical contact.</p>
    <h2 class="heading settled" data-level="1" id="intro"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#intro"></a></h2>
    <p>The Proximity Sensor extends the Generic Sensor API <a data-link-type="biblio" href="#biblio-generic-sensor">[GENERIC-SENSOR]</a> to provide information about proximity level, as detected by the device’s primary
 proximity sensor. The proximity level is reported as the distance (in centimeter)
-from the sensor to the closest visible surface. <a href="#limitations-proximity-sensors">§7 Limitations of Proximity Sensors</a> describes more about the potential limitations, why the precise distance value
+from the sensor to the closest visible surface. <a href="#limitations-proximity-sensors">§8 Limitations of Proximity Sensors</a> describes more about the potential limitations, why the precise distance value
 reported by different devices can be different, due to differences in detection
 method, sensor construction, etc.  Moreover some proximity sensors might be only
 able to provide just a boolean to indicate if there is a physical object which is near,
 more like presence detection, than an absolute value for the distance.</p>
    <h2 class="heading settled" data-level="2" id="examples"><span class="secno">2. </span><span class="content">Examples</span><a class="self-link" href="#examples"></a></h2>
-   <div class="example" id="example-fbf52dff">
-    <a class="self-link" href="#example-fbf52dff"></a> 
-<pre class="highlight"><span class="kd">let</span> sensor <span class="o">=</span> <span class="k">new</span> ProximitySensor<span class="p">();</span>
-sensor<span class="p">.</span>start<span class="p">();</span>
+   <div class="example" id="example-773aa098">
+    <a class="self-link" href="#example-773aa098"></a> 
+<pre class="highlight"><c- a>let</c-> sensor <c- o>=</c-> <c- k>new</c-> ProximitySensor<c- p>();</c->
+sensor<c- p>.</c->start<c- p>();</c->
 
-sensor<span class="p">.</span>onreading <span class="o">=</span> <span class="p">()</span> <span class="p">=></span> console<span class="p">.</span>log<span class="p">(</span>sensor<span class="p">.</span>distance<span class="p">);</span>
+sensor<c- p>.</c->onreading <c- o>=</c-> <c- p>()</c-> <c- o>=></c-> console<c- p>.</c->log<c- p>(</c->sensor<c- p>.</c->distance<c- p>);</c->
 
-sensor<span class="p">.</span>onerror <span class="o">=</span> event <span class="p">=></span> console<span class="p">.</span>log<span class="p">(</span>event<span class="p">.</span>error<span class="p">.</span>name<span class="p">,</span> event<span class="p">.</span>error<span class="p">.</span>message<span class="p">);</span>
+sensor<c- p>.</c->onerror <c- o>=</c-> event <c- o>=></c-> console<c- p>.</c->log<c- p>(</c->event<c- p>.</c->error<c- p>.</c->name<c- p>,</c-> event<c- p>.</c->error<c- p>.</c->message<c- p>);</c->
 </pre>
    </div>
    <h2 class="heading settled" data-level="3" id="security-and-privacy"><span class="secno">3. </span><span class="content">Security and Privacy Considerations</span><a class="self-link" href="#security-and-privacy"></a></h2>
@@ -1555,31 +1608,31 @@ sensor<span class="p">.</span>onerror <span class="o">=</span> event <span class
 thus, may expose privacy sensitive information for <a data-link-type="dfn" href="https://w3c.github.io/sensors#user-identifying" id="ref-for-user-identifying">user identifying</a> and/or <a data-link-type="dfn" href="https://w3c.github.io/sensors#device-fingerprinting" id="ref-for-device-fingerprinting">fingerprinting</a> attacks.</p>
    <p>To mitigate these, user agents should use one or both of the following <a data-link-type="dfn" href="https://w3c.github.io/sensors#mitigation-strategies" id="ref-for-mitigation-strategies">mitigation strategies</a>:</p>
    <ul>
-    <li data-md="">
+    <li data-md>
      <p><a data-link-type="dfn" href="https://w3c.github.io/sensors/#reduce-accuracy" id="ref-for-reduce-accuracy">reduce accuracy</a> of a <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-readings" id="ref-for-sensor-readings">sensor reading</a></p>
-    <li data-md="">
+    <li data-md>
      <p><a data-link-type="dfn" href="https://w3c.github.io/sensors/#limit-max-frequency" id="ref-for-limit-max-frequency">limit maximum sampling frequency</a></p>
    </ul>
    <p>These mitigation strategies complement the <a data-link-type="dfn" href="https://w3c.github.io/sensors#mitigation-strategies" id="ref-for-mitigation-strategies①">generic mitigations</a> defined in the Generic Sensor API <a data-link-type="biblio" href="#biblio-generic-sensor">[GENERIC-SENSOR]</a>.</p>
    <h2 class="heading settled" data-level="4" id="model"><span class="secno">4. </span><span class="content">Model</span><a class="self-link" href="#model"></a></h2>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="proximity-sensor">Proximity Sensor</dfn> <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-type" id="ref-for-sensor-type">sensor type</a>’s associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor">Sensor</a></code> subclass is the <code class="idl"><a data-link-type="idl" href="#proximitysensor" id="ref-for-proximitysensor">ProximitySensor</a></code> class.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="proximity-sensor">Proximity Sensor</dfn> <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-type" id="ref-for-sensor-type">sensor type</a>’s associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor">Sensor</a></code> subclass is the <code class="idl"><a data-link-type="idl" href="#proximitysensor" id="ref-for-proximitysensor">ProximitySensor</a></code> class.</p>
    <p>The <a data-link-type="dfn" href="#proximity-sensor" id="ref-for-proximity-sensor">Proximity Sensor</a> has a <a data-link-type="dfn" href="https://w3c.github.io/sensors#default-sensor" id="ref-for-default-sensor">default sensor</a>,
 which is the device’s main proximity detector.</p>
    <p>A <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading" id="ref-for-latest-reading">latest reading</a> for a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor①">Sensor</a></code> of <a data-link-type="dfn" href="#proximity-sensor" id="ref-for-proximity-sensor①">Proximity Sensor</a> <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-type" id="ref-for-sensor-type①">sensor type</a> includes three <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry">entries</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key">keys</a> are "distance", "max", "near" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value">values</a> contain <a data-link-type="dfn" href="#distance" id="ref-for-distance">distance</a>, <a data-link-type="dfn" href="#max" id="ref-for-max">max</a> and <a data-link-type="dfn" href="#near" id="ref-for-near">near</a> values.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="distance">distance</dfn> is a value that represents the distance between a device and
-the closest visible surface of the physical object within the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensing-range">sensing range</dfn>.
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="distance">distance</dfn> is a value that represents the distance between a device and
+the closest visible surface of the physical object within the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="sensing-range">sensing range</dfn>.
 Its unit is the centimeter (cm).</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="max">max</dfn> is a value that represents the maximum <a data-link-type="dfn" href="#sensing-range" id="ref-for-sensing-range">sensing range</a> of the
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="max">max</dfn> is a value that represents the maximum <a data-link-type="dfn" href="#sensing-range" id="ref-for-sensing-range">sensing range</a> of the
 main proximity detector, in centimeters.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="near">near</dfn> is a value that represent the presence of a visible surface
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="near">near</dfn> is a value that represent the presence of a visible surface
 in the vicinity of the main proximity detector.</p>
    <h2 class="heading settled" data-level="5" id="api"><span class="secno">5. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
    <h3 class="heading settled" data-level="5.1" id="proximity-sensor-interface"><span class="secno">5.1. </span><span class="content">The ProximitySensor Interface</span><a class="self-link" href="#proximity-sensor-interface"></a></h3>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="ProximitySensor" data-dfn-type="constructor" data-export="" data-lt="ProximitySensor(sensorOptions)|ProximitySensor()" id="dom-proximitysensor-proximitysensor"><code>Constructor</code><a class="self-link" href="#dom-proximitysensor-proximitysensor"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions">SensorOptions</a> <dfn class="nv idl-code" data-dfn-for="ProximitySensor/ProximitySensor(sensorOptions)" data-dfn-type="argument" data-export="" id="dom-proximitysensor-proximitysensor-sensoroptions-sensoroptions"><code>sensorOptions</code><a class="self-link" href="#dom-proximitysensor-proximitysensor-sensoroptions-sensoroptions"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="proximitysensor"><code>ProximitySensor</code></dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor②">Sensor</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double"><span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="ProximitySensor" data-dfn-type="attribute" data-export="" data-readonly="" data-type="double?" id="dom-proximitysensor-distance"><code>distance</code></dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①"><span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="ProximitySensor" data-dfn-type="attribute" data-export="" data-readonly="" data-type="double?" id="dom-proximitysensor-max"><code>max</code></dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean"><span class="kt">boolean</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="ProximitySensor" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean?" id="dom-proximitysensor-near"><code>near</code></dfn>;
+<pre class="idl highlight def">[<dfn class="idl-code" data-dfn-for="ProximitySensor" data-dfn-type="constructor" data-export data-lt="ProximitySensor(sensorOptions)|ProximitySensor()" id="dom-proximitysensor-proximitysensor"><code><c- g>Constructor</c-></code><a class="self-link" href="#dom-proximitysensor-proximitysensor"></a></dfn>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions"><c- n>SensorOptions</c-></a> <dfn class="idl-code" data-dfn-for="ProximitySensor/ProximitySensor(sensorOptions)" data-dfn-type="argument" data-export id="dom-proximitysensor-proximitysensor-sensoroptions-sensoroptions"><code><c- g>sensorOptions</c-></code><a class="self-link" href="#dom-proximitysensor-proximitysensor-sensoroptions-sensoroptions"></a></dfn>), <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="proximitysensor"><code><c- g>ProximitySensor</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor②"><c- n>Sensor</c-></a> {
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double"><c- b>double</c-></a>? <dfn class="dfn-paneled idl-code" data-dfn-for="ProximitySensor" data-dfn-type="attribute" data-export data-readonly data-type="double?" id="dom-proximitysensor-distance"><code><c- g>distance</c-></code></dfn>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①"><c- b>double</c-></a>? <dfn class="dfn-paneled idl-code" data-dfn-for="ProximitySensor" data-dfn-type="attribute" data-export data-readonly data-type="double?" id="dom-proximitysensor-max"><code><c- g>max</c-></code></dfn>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean"><c- b>boolean</c-></a>? <dfn class="dfn-paneled idl-code" data-dfn-for="ProximitySensor" data-dfn-type="attribute" data-export data-readonly data-type="boolean?" id="dom-proximitysensor-near"><code><c- g>near</c-></code></dfn>;
 };
 </pre>
    <p>To construct a <code class="idl"><a data-link-type="idl" href="#proximitysensor" id="ref-for-proximitysensor①">ProximitySensor</a></code> object the user agent must invoke the <a data-link-type="dfn" href="#construct-a-proximity-sensor-object" id="ref-for-construct-a-proximity-sensor-object">construct a proximity sensor object</a> abstract operation.</p>
@@ -1594,34 +1647,45 @@ in the vicinity of the main proximity detector.</p>
    <p class="note" role="note"><span>Note:</span> If the implementation is unable to provide the <a data-link-type="dfn" href="#near" id="ref-for-near①">near</a> value, it could infer the <a data-link-type="dfn" href="#near" id="ref-for-near②">near</a> value from the value of <a data-link-type="dfn" href="#distance" id="ref-for-distance①">distance</a>. For example, if <a data-link-type="dfn" href="#distance" id="ref-for-distance②">distance</a> is not equal to <a data-link-type="dfn" href="#max" id="ref-for-max①">max</a>, it
 could imply there is a physical object in the <a data-link-type="dfn" href="#sensing-range" id="ref-for-sensing-range③">sensing range</a>.</p>
    <h2 class="heading settled" data-level="6" id="abstract-operations"><span class="secno">6. </span><span class="content">Abstract Operations</span><a class="self-link" href="#abstract-operations"></a></h2>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="6.1" data-lt="Construct a proximity sensor object" id="construct-a-proximity-sensor-object"><span class="secno">6.1. </span><span class="content">Construct a proximity sensor object</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export data-level="6.1" data-lt="Construct a proximity sensor object" id="construct-a-proximity-sensor-object"><span class="secno">6.1. </span><span class="content">Construct a proximity sensor object</span></h3>
    <div class="algorithm" data-algorithm="construct a proximity sensor object">
     <dl>
-     <dt data-md="">input
-     <dd data-md="">
+     <dt data-md>input
+     <dd data-md>
       <p><var>options</var>, a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions①">SensorOptions</a></code> object.</p>
-     <dt data-md="">output
-     <dd data-md="">
+     <dt data-md>output
+     <dd data-md>
       <p>A <code class="idl"><a data-link-type="idl" href="#proximitysensor" id="ref-for-proximitysensor⑤">ProximitySensor</a></code> object.</p>
     </dl>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>allowed</var> be the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors#check-sensor-policy-controlled-features" id="ref-for-check-sensor-policy-controlled-features">check sensor policy-controlled features</a> with <code class="idl"><a data-link-type="idl" href="#proximitysensor" id="ref-for-proximitysensor⑥">ProximitySensor</a></code>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>allowed</var> is false, then:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw" id="ref-for-dfn-throw">Throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror" id="ref-for-securityerror">SecurityError</a></code> <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException">DOMException</a></code>.</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>proximity_sensor</var> be the new <code class="idl"><a data-link-type="idl" href="#proximitysensor" id="ref-for-proximitysensor⑦">ProximitySensor</a></code> object.</p>
-     <li data-md="">
+     <li data-md>
       <p>Invoke <a data-link-type="dfn" href="https://w3c.github.io/sensors#initialize-a-sensor-object" id="ref-for-initialize-a-sensor-object">initialize a sensor object</a> with <var>proximity_sensor</var> and <var>options</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Return <var>proximity_sensor</var>.</p>
     </ol>
    </div>
-   <h2 class="heading settled" data-level="7" id="limitations-proximity-sensors"><span class="secno">7. </span><span class="content">Limitations of Proximity Sensors</span><a class="self-link" href="#limitations-proximity-sensors"></a></h2>
+   <h2 class="heading settled" data-level="7" id="automation"><span class="secno">7. </span><span class="content">Automation</span><a class="self-link" href="#automation"></a></h2>
+    This section extends the <a data-link-type="dfn" href="https://w3c.github.io/sensors#automation" id="ref-for-automation">automation</a> section defined in the Generic Sensor API <a data-link-type="biblio" href="#biblio-generic-sensor">[GENERIC-SENSOR]</a> to provide mocking information about the proximity level for the purposes of
+testing a user agent’s implementation of <code class="idl"><a data-link-type="idl" href="#proximitysensor" id="ref-for-proximitysensor⑧">ProximitySensor</a></code> API. 
+   <h3 class="heading settled" data-level="7.1" id="mock-proximity-sensor-type"><span class="secno">7.1. </span><span class="content">Mock Sensor Type</span><a class="self-link" href="#mock-proximity-sensor-type"></a></h3>
+   <p>The <code class="idl"><a data-link-type="idl" href="#proximitysensor" id="ref-for-proximitysensor⑨">ProximitySensor</a></code> class has an associated <a data-link-type="dfn" href="https://w3c.github.io/sensors#mock-sensor-type" id="ref-for-mock-sensor-type">mock sensor type</a> which is <a class="idl-code" data-link-type="enum-value">"proximity"</a>, its <a data-link-type="dfn" href="https://w3c.github.io/sensors#mock-sensor-reading-values" id="ref-for-mock-sensor-reading-values">mock sensor reading values</a> dictionary is defined as follow:</p>
+<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="idl-code" data-dfn-type="dictionary" data-export id="dictdef-proximityreadingvalues"><code><c- g>ProximityReadingValues</c-></code><a class="self-link" href="#dictdef-proximityreadingvalues"></a></dfn> {
+  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="ProximityReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-proximityreadingvalues-distance"><code><c- g>distance</c-></code><a class="self-link" href="#dom-proximityreadingvalues-distance"></a></dfn>;
+  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double③"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="ProximityReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-proximityreadingvalues-max"><code><c- g>max</c-></code><a class="self-link" href="#dom-proximityreadingvalues-max"></a></dfn>;
+  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①"><c- b>boolean</c-></a>? <dfn class="idl-code" data-dfn-for="ProximityReadingValues" data-dfn-type="dict-member" data-export data-type="boolean? " id="dom-proximityreadingvalues-near"><code><c- g>near</c-></code><a class="self-link" href="#dom-proximityreadingvalues-near"></a></dfn>;
+};
+</pre>
+   <h2 class="heading settled" data-level="8" id="limitations-proximity-sensors"><span class="secno">8. </span><span class="content">Limitations of Proximity Sensors</span><a class="self-link" href="#limitations-proximity-sensors"></a></h2>
    <p>Since most proximity sensors detect electromagnetic radiation (e.g., an infrared light
 or a magnetic field), certain material properties can interfere with the sensor’s
 ability to sense the presence of a physical object. Things that can interfere with
@@ -1632,11 +1696,11 @@ should not be relied on as a means to measure distance. The only thing that can
 be deduced from a proximity sensor is that a physical object is somewhere in the
 distance between the minimum sensing distance and the maximum sensing distance
 with some degree of certainty.</p>
-   <h2 class="heading settled" data-level="8" id="acknowledgements"><span class="secno">8. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
+   <h2 class="heading settled" data-level="9" id="acknowledgements"><span class="secno">9. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
    <p>Tobie Langel for the work on Generic Sensor API and inputs on this specification.
 Doug Turner for the initial prototype and
 Marcos Caceres for the test suite.</p>
-   <h2 class="heading settled" data-level="9" id="conformance"><span class="secno">9. </span><span class="content">Conformance</span><a class="self-link" href="#conformance"></a></h2>
+   <h2 class="heading settled" data-level="10" id="conformance"><span class="secno">10. </span><span class="content">Conformance</span><a class="self-link" href="#conformance"></a></h2>
    <p>Conformance requirements are expressed with a combination of
 descriptive assertions and RFC 2119 terminology. The key words "MUST",
 "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
@@ -1646,7 +1710,7 @@ However, for readability, these words do not appear in all uppercase
 letters in this specification.</p>
    <p>All of the text of this specification is normative except sections
 explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a></p>
-   <p>A <dfn data-dfn-type="dfn" data-noexport="" id="conformant-user-agent">conformant user agent<a class="self-link" href="#conformant-user-agent"></a></dfn> must implement all the requirements
+   <p>A <dfn data-dfn-type="dfn" data-noexport id="conformant-user-agent">conformant user agent<a class="self-link" href="#conformant-user-agent"></a></dfn> must implement all the requirements
 listed in this specification that are applicable to user agents.</p>
    <p>The IDL fragments in this specification must be interpreted as required for
 conforming IDL fragments, as described in the Web IDL specification. <a data-link-type="biblio" href="#biblio-webidl">[WEBIDL]</a></p>
@@ -1655,76 +1719,251 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#conformant-user-agent">conformant user agent</a><span>, in §9</span>
+   <li><a href="#conformant-user-agent">conformant user agent</a><span>, in §10</span>
    <li><a href="#construct-a-proximity-sensor-object">Construct a proximity sensor object</a><span>, in §6</span>
    <li>
     distance
     <ul>
-     <li><a href="#distance">definition of</a><span>, in §4</span>
      <li><a href="#dom-proximitysensor-distance">attribute for ProximitySensor</a><span>, in §5.1</span>
+     <li><a href="#distance">definition of</a><span>, in §4</span>
+     <li><a href="#dom-proximityreadingvalues-distance">dict-member for ProximityReadingValues</a><span>, in §7.1</span>
     </ul>
    <li>
     max
     <ul>
-     <li><a href="#max">definition of</a><span>, in §4</span>
      <li><a href="#dom-proximitysensor-max">attribute for ProximitySensor</a><span>, in §5.1</span>
+     <li><a href="#max">definition of</a><span>, in §4</span>
+     <li><a href="#dom-proximityreadingvalues-max">dict-member for ProximityReadingValues</a><span>, in §7.1</span>
     </ul>
    <li>
     near
     <ul>
-     <li><a href="#near">definition of</a><span>, in §4</span>
      <li><a href="#dom-proximitysensor-near">attribute for ProximitySensor</a><span>, in §5.1</span>
+     <li><a href="#near">definition of</a><span>, in §4</span>
+     <li><a href="#dom-proximityreadingvalues-near">dict-member for ProximityReadingValues</a><span>, in §7.1</span>
     </ul>
+   <li><a href="#dictdef-proximityreadingvalues">ProximityReadingValues</a><span>, in §7.1</span>
    <li><a href="#proximitysensor">ProximitySensor</a><span>, in §5.1</span>
    <li><a href="#proximity-sensor">Proximity Sensor</a><span>, in §4</span>
    <li><a href="#dom-proximitysensor-proximitysensor">ProximitySensor()</a><span>, in §5.1</span>
    <li><a href="#dom-proximitysensor-proximitysensor">ProximitySensor(sensorOptions)</a><span>, in §5.1</span>
    <li><a href="#sensing-range">sensing range</a><span>, in §4</span>
   </ul>
+  <aside class="dfn-panel" data-for="term-for-sensor">
+   <a href="https://w3c.github.io/sensors/#sensor">https://w3c.github.io/sensors/#sensor</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-sensor">4. Model</a> <a href="#ref-for-sensor①">(2)</a>
+    <li><a href="#ref-for-sensor②">5.1. The ProximitySensor Interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dictdef-sensoroptions">
+   <a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">https://w3c.github.io/sensors/#dictdef-sensoroptions</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-sensoroptions">5.1. The ProximitySensor Interface</a>
+    <li><a href="#ref-for-dictdef-sensoroptions①">6.1. Construct a proximity sensor object</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-automation">
+   <a href="https://w3c.github.io/sensors#automation">https://w3c.github.io/sensors#automation</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-automation">7. Automation</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-check-sensor-policy-controlled-features">
+   <a href="https://w3c.github.io/sensors#check-sensor-policy-controlled-features">https://w3c.github.io/sensors#check-sensor-policy-controlled-features</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-check-sensor-policy-controlled-features">6.1. Construct a proximity sensor object</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-default-sensor">
+   <a href="https://w3c.github.io/sensors#default-sensor">https://w3c.github.io/sensors#default-sensor</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-default-sensor">4. Model</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-device-fingerprinting">
+   <a href="https://w3c.github.io/sensors#device-fingerprinting">https://w3c.github.io/sensors#device-fingerprinting</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-device-fingerprinting">3. Security and Privacy Considerations</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-get-value-from-latest-reading">
+   <a href="https://w3c.github.io/sensors/#get-value-from-latest-reading">https://w3c.github.io/sensors/#get-value-from-latest-reading</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-get-value-from-latest-reading">5.1.1. The distance attribute</a>
+    <li><a href="#ref-for-get-value-from-latest-reading①">5.1.2. The max attribute</a>
+    <li><a href="#ref-for-get-value-from-latest-reading②">5.1.3. The near attribute</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-initialize-a-sensor-object">
+   <a href="https://w3c.github.io/sensors#initialize-a-sensor-object">https://w3c.github.io/sensors#initialize-a-sensor-object</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-initialize-a-sensor-object">6.1. Construct a proximity sensor object</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-latest-reading">
+   <a href="https://w3c.github.io/sensors#latest-reading">https://w3c.github.io/sensors#latest-reading</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-latest-reading">4. Model</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-limit-max-frequency">
+   <a href="https://w3c.github.io/sensors/#limit-max-frequency">https://w3c.github.io/sensors/#limit-max-frequency</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-limit-max-frequency">3. Security and Privacy Considerations</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-mitigation-strategies">
+   <a href="https://w3c.github.io/sensors#mitigation-strategies">https://w3c.github.io/sensors#mitigation-strategies</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-mitigation-strategies">3. Security and Privacy Considerations</a> <a href="#ref-for-mitigation-strategies①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-mock-sensor-reading-values">
+   <a href="https://w3c.github.io/sensors#mock-sensor-reading-values">https://w3c.github.io/sensors#mock-sensor-reading-values</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-mock-sensor-reading-values">7.1. Mock Sensor Type</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-mock-sensor-type">
+   <a href="https://w3c.github.io/sensors#mock-sensor-type">https://w3c.github.io/sensors#mock-sensor-type</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-mock-sensor-type">7.1. Mock Sensor Type</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-reduce-accuracy">
+   <a href="https://w3c.github.io/sensors/#reduce-accuracy">https://w3c.github.io/sensors/#reduce-accuracy</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-reduce-accuracy">3. Security and Privacy Considerations</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-sensor-readings">
+   <a href="https://w3c.github.io/sensors#sensor-readings">https://w3c.github.io/sensors#sensor-readings</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-sensor-readings">3. Security and Privacy Considerations</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-sensor-type">
+   <a href="https://w3c.github.io/sensors#sensor-type">https://w3c.github.io/sensors#sensor-type</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-sensor-type">4. Model</a> <a href="#ref-for-sensor-type①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-user-identifying">
+   <a href="https://w3c.github.io/sensors#user-identifying">https://w3c.github.io/sensors#user-identifying</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-user-identifying">3. Security and Privacy Considerations</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-map-entry">
+   <a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-map-entry">4. Model</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-map-key">
+   <a href="https://infra.spec.whatwg.org/#map-key">https://infra.spec.whatwg.org/#map-key</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-map-key">4. Model</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-map-value">
+   <a href="https://infra.spec.whatwg.org/#map-value">https://infra.spec.whatwg.org/#map-value</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-map-value">4. Model</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
+   <a href="https://heycam.github.io/webidl/#idl-DOMException">https://heycam.github.io/webidl/#idl-DOMException</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-DOMException">6.1. Construct a proximity sensor object</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-Exposed">
+   <a href="https://heycam.github.io/webidl/#Exposed">https://heycam.github.io/webidl/#Exposed</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-Exposed">5.1. The ProximitySensor Interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-SecureContext">
+   <a href="https://heycam.github.io/webidl/#SecureContext">https://heycam.github.io/webidl/#SecureContext</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-SecureContext">5.1. The ProximitySensor Interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-securityerror">
+   <a href="https://heycam.github.io/webidl/#securityerror">https://heycam.github.io/webidl/#securityerror</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-securityerror">6.1. Construct a proximity sensor object</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-boolean">
+   <a href="https://heycam.github.io/webidl/#idl-boolean">https://heycam.github.io/webidl/#idl-boolean</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-boolean">5.1. The ProximitySensor Interface</a>
+    <li><a href="#ref-for-idl-boolean①">7.1. Mock Sensor Type</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-double">
+   <a href="https://heycam.github.io/webidl/#idl-double">https://heycam.github.io/webidl/#idl-double</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-double">5.1. The ProximitySensor Interface</a> <a href="#ref-for-idl-double①">(2)</a>
+    <li><a href="#ref-for-idl-double②">7.1. Mock Sensor Type</a> <a href="#ref-for-idl-double③">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-throw">
+   <a href="https://heycam.github.io/webidl/#dfn-throw">https://heycam.github.io/webidl/#dfn-throw</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-throw">6.1. Construct a proximity sensor object</a>
+   </ul>
+  </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
     <a data-link-type="biblio">[GENERIC-SENSOR]</a> defines the following terms:
     <ul>
-     <li><a href="https://w3c.github.io/sensors/#sensor">Sensor</a>
-     <li><a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a>
-     <li><a href="https://w3c.github.io/sensors#check-sensor-policy-controlled-features">check sensor policy-controlled features</a>
-     <li><a href="https://w3c.github.io/sensors#default-sensor">default sensor</a>
-     <li><a href="https://w3c.github.io/sensors#device-fingerprinting">fingerprinting</a>
-     <li><a href="https://w3c.github.io/sensors/#get-value-from-latest-reading">get value from latest reading</a>
-     <li><a href="https://w3c.github.io/sensors#initialize-a-sensor-object">initialize a sensor object</a>
-     <li><a href="https://w3c.github.io/sensors#latest-reading">latest reading</a>
-     <li><a href="https://w3c.github.io/sensors/#limit-max-frequency">limit maximum sampling frequency</a>
-     <li><a href="https://w3c.github.io/sensors#mitigation-strategies">mitigation strategies</a>
-     <li><a href="https://w3c.github.io/sensors/#reduce-accuracy">reduce accuracy</a>
-     <li><a href="https://w3c.github.io/sensors#sensor-readings">sensor readings</a>
-     <li><a href="https://w3c.github.io/sensors#sensor-type">sensor type</a>
-     <li><a href="https://w3c.github.io/sensors#user-identifying">user identifying</a>
+     <li><span class="dfn-paneled" id="term-for-sensor" style="color:initial">Sensor</span>
+     <li><span class="dfn-paneled" id="term-for-dictdef-sensoroptions" style="color:initial">SensorOptions</span>
+     <li><span class="dfn-paneled" id="term-for-automation" style="color:initial">automation</span>
+     <li><span class="dfn-paneled" id="term-for-check-sensor-policy-controlled-features" style="color:initial">check sensor policy-controlled features</span>
+     <li><span class="dfn-paneled" id="term-for-default-sensor" style="color:initial">default sensor</span>
+     <li><span class="dfn-paneled" id="term-for-device-fingerprinting" style="color:initial">fingerprinting</span>
+     <li><span class="dfn-paneled" id="term-for-get-value-from-latest-reading" style="color:initial">get value from latest reading</span>
+     <li><span class="dfn-paneled" id="term-for-initialize-a-sensor-object" style="color:initial">initialize a sensor object</span>
+     <li><span class="dfn-paneled" id="term-for-latest-reading" style="color:initial">latest reading</span>
+     <li><span class="dfn-paneled" id="term-for-limit-max-frequency" style="color:initial">limit maximum sampling frequency</span>
+     <li><span class="dfn-paneled" id="term-for-mitigation-strategies" style="color:initial">mitigation strategies</span>
+     <li><span class="dfn-paneled" id="term-for-mock-sensor-reading-values" style="color:initial">mock sensor reading values</span>
+     <li><span class="dfn-paneled" id="term-for-mock-sensor-type" style="color:initial">mock sensor type</span>
+     <li><span class="dfn-paneled" id="term-for-reduce-accuracy" style="color:initial">reduce accuracy</span>
+     <li><span class="dfn-paneled" id="term-for-sensor-readings" style="color:initial">sensor readings</span>
+     <li><span class="dfn-paneled" id="term-for-sensor-type" style="color:initial">sensor type</span>
+     <li><span class="dfn-paneled" id="term-for-user-identifying" style="color:initial">user identifying</span>
     </ul>
    <li>
     <a data-link-type="biblio">[INFRA]</a> defines the following terms:
     <ul>
-     <li><a href="https://infra.spec.whatwg.org/#map-entry">entry</a>
-     <li><a href="https://infra.spec.whatwg.org/#map-key">key</a>
-     <li><a href="https://infra.spec.whatwg.org/#map-value">value</a>
+     <li><span class="dfn-paneled" id="term-for-map-entry" style="color:initial">entry</span>
+     <li><span class="dfn-paneled" id="term-for-map-key" style="color:initial">key</span>
+     <li><span class="dfn-paneled" id="term-for-map-value" style="color:initial">value</span>
     </ul>
    <li>
     <a data-link-type="biblio">[WEBIDL]</a> defines the following terms:
     <ul>
-     <li><a href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a>
-     <li><a href="https://heycam.github.io/webidl/#Exposed">Exposed</a>
-     <li><a href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>
-     <li><a href="https://heycam.github.io/webidl/#securityerror">SecurityError</a>
-     <li><a href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>
-     <li><a href="https://heycam.github.io/webidl/#idl-double">double</a>
-     <li><a href="https://heycam.github.io/webidl/#dfn-throw">throw</a>
+     <li><span class="dfn-paneled" id="term-for-idl-DOMException" style="color:initial">DOMException</span>
+     <li><span class="dfn-paneled" id="term-for-Exposed" style="color:initial">Exposed</span>
+     <li><span class="dfn-paneled" id="term-for-SecureContext" style="color:initial">SecureContext</span>
+     <li><span class="dfn-paneled" id="term-for-securityerror" style="color:initial">SecurityError</span>
+     <li><span class="dfn-paneled" id="term-for-idl-boolean" style="color:initial">boolean</span>
+     <li><span class="dfn-paneled" id="term-for-idl-double" style="color:initial">double</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-throw" style="color:initial">throw</span>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
    <dt id="biblio-generic-sensor">[GENERIC-SENSOR]
-   <dd>Rick Waldron; et al. <a href="https://w3c.github.io/sensors/">Generic Sensor API</a>. URL: <a href="https://w3c.github.io/sensors/">https://w3c.github.io/sensors/</a>
+   <dd>Rick Waldron; Mikhail Pozdnyakov; Alexander Shalamov. <a href="https://w3c.github.io/sensors/">Generic Sensor API</a>. URL: <a href="https://w3c.github.io/sensors/">https://w3c.github.io/sensors/</a>
    <dt id="biblio-infra">[INFRA]
    <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/">Infra Standard</a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
    <dt id="biblio-rfc2119">[RFC2119]
@@ -1733,11 +1972,17 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://heycam.github.io/webidl/">Web IDL</a>. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl highlight def">[<a class="nv" href="#dom-proximitysensor-proximitysensor"><code>Constructor</code></a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions②">SensorOptions</a> <a class="nv" href="#dom-proximitysensor-proximitysensor-sensoroptions-sensoroptions"><code>sensorOptions</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext①">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <a class="nv" href="#proximitysensor"><code>ProximitySensor</code></a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor②①">Sensor</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②"><span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="double?" href="#dom-proximitysensor-distance"><code>distance</code></a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①①"><span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="double?" href="#dom-proximitysensor-max"><code>max</code></a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①"><span class="kt">boolean</span></a>? <a class="nv" data-readonly="" data-type="boolean?" href="#dom-proximitysensor-near"><code>near</code></a>;
+<pre class="idl highlight def">[<a href="#dom-proximitysensor-proximitysensor"><code><c- g>Constructor</c-></code></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions②"><c- n>SensorOptions</c-></a> <a href="#dom-proximitysensor-proximitysensor-sensoroptions-sensoroptions"><code><c- g>sensorOptions</c-></code></a>), <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext①"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <a href="#proximitysensor"><code><c- g>ProximitySensor</c-></code></a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor②①"><c- n>Sensor</c-></a> {
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double④"><c- b>double</c-></a>? <a data-readonly data-type="double?" href="#dom-proximitysensor-distance"><code><c- g>distance</c-></code></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①①"><c- b>double</c-></a>? <a data-readonly data-type="double?" href="#dom-proximitysensor-max"><code><c- g>max</c-></code></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②"><c- b>boolean</c-></a>? <a data-readonly data-type="boolean?" href="#dom-proximitysensor-near"><code><c- g>near</c-></code></a>;
+};
+
+<c- b>dictionary</c-> <a href="#dictdef-proximityreadingvalues"><code><c- g>ProximityReadingValues</c-></code></a> {
+  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-proximityreadingvalues-distance"><code><c- g>distance</c-></code></a>;
+  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double③①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-proximityreadingvalues-max"><code><c- g>max</c-></code></a>;
+  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①①"><c- b>boolean</c-></a>? <a data-type="boolean? " href="#dom-proximityreadingvalues-near"><code><c- g>near</c-></code></a>;
 };
 
 </pre>
@@ -1785,6 +2030,8 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-proximitysensor③">5.1.2. The max attribute</a>
     <li><a href="#ref-for-proximitysensor④">5.1.3. The near attribute</a>
     <li><a href="#ref-for-proximitysensor⑤">6.1. Construct a proximity sensor object</a> <a href="#ref-for-proximitysensor⑥">(2)</a> <a href="#ref-for-proximitysensor⑦">(3)</a>
+    <li><a href="#ref-for-proximitysensor⑧">7. Automation</a>
+    <li><a href="#ref-for-proximitysensor⑨">7.1. Mock Sensor Type</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-proximitysensor-distance">
@@ -1811,60 +2058,143 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-construct-a-proximity-sensor-object">5.1. The ProximitySensor Interface</a>
    </ul>
   </aside>
+<script>/* script-var-click-highlighting */
+
+    document.addEventListener("click", e=>{
+        if(e.target.nodeName == "VAR") {
+            highlightSameAlgoVars(e.target);
+        }
+    });
+    {
+        const indexCounts = new Map();
+        const indexNames = new Map();
+        function highlightSameAlgoVars(v) {
+            // Find the algorithm container.
+            let algoContainer = null;
+            let searchEl = v;
+            while(algoContainer == null && searchEl != document.body) {
+                searchEl = searchEl.parentNode;
+                if(searchEl.hasAttribute("data-algorithm")) {
+                    algoContainer = searchEl;
+                }
+            }
+
+            // Not highlighting document-global vars,
+            // too likely to be unrelated.
+            if(algoContainer == null) return;
+
+            const algoName = algoContainer.getAttribute("data-algorithm");
+            const varName = getVarName(v);
+            const addClass = !v.classList.contains("selected");
+            let highlightClass = null;
+            if(addClass) {
+                const index = chooseHighlightIndex(algoName, varName);
+                indexCounts.get(algoName)[index] += 1;
+                indexNames.set(algoName+"///"+varName, index);
+                highlightClass = nameFromIndex(index);
+            } else {
+                const index = previousHighlightIndex(algoName, varName);
+                indexCounts.get(algoName)[index] -= 1;
+                highlightClass = nameFromIndex(index);
+            }
+
+            // Find all same-name vars, and toggle their class appropriately.
+            for(const el of algoContainer.querySelectorAll("var")) {
+                if(getVarName(el) == varName) {
+                    el.classList.toggle("selected", addClass);
+                    el.classList.toggle(highlightClass, addClass);
+                }
+            }
+        }
+        function getVarName(el) {
+            return el.textContent.replace(/(\s| )+/, " ").trim();
+        }
+        function chooseHighlightIndex(algoName, varName) {
+            let indexes = null;
+            if(indexCounts.has(algoName)) {
+                indexes = indexCounts.get(algoName);
+            } else {
+                // 7 classes right now
+                indexes = [0,0,0,0,0,0,0];
+                indexCounts.set(algoName, indexes);
+            }
+
+            // If the element was recently unclicked,
+            // *and* that color is still unclaimed,
+            // give it back the same color.
+            const lastIndex = previousHighlightIndex(algoName, varName);
+            if(indexes[lastIndex] === 0) return lastIndex;
+
+            // Find the earliest index with the lowest count.
+            const minCount = Math.min.apply(null, indexes);
+            let index = null;
+            for(var i = 0; i < indexes.length; i++) {
+                if(indexes[i] == minCount) {
+                    return i;
+                }
+            }
+        }
+        function previousHighlightIndex(algoName, varName) {
+            return indexNames.get(algoName+"///"+varName);
+        }
+        function nameFromIndex(index) {
+            return "selected" + index;
+        }
+    }
+    </script>
 <script>/* script-dfn-panel */
 
-        document.body.addEventListener("click", function(e) {
-            var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-            // Find the dfn element or panel, if any, that was clicked on.
-            var el = e.target;
-            var target;
-            var hitALink = false;
-            while(el.parentElement) {
-                if(el.tagName == "A") {
-                    // Clicking on a link in a <dfn> shouldn't summon the panel
-                    hitALink = true;
-                }
-                if(el.classList.contains("dfn-paneled")) {
-                    target = "dfn";
-                    break;
-                }
-                if(el.classList.contains("dfn-panel")) {
-                    target = "dfn-panel";
-                    break;
-                }
-                el = el.parentElement;
-            }
-            if(target != "dfn-panel") {
-                // Turn off any currently "on" or "activated" panels.
-                queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-                    el.classList.remove("on");
-                    el.classList.remove("activated");
-                });
-            }
-            if(target == "dfn" && !hitALink) {
-                // open the panel
-                var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-                if(dfnPanel) {
-                    console.log(dfnPanel);
-                    dfnPanel.classList.add("on");
-                    var rect = el.getBoundingClientRect();
-                    dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-                    dfnPanel.style.top = window.scrollY + rect.top + "px";
-                    var panelRect = dfnPanel.getBoundingClientRect();
-                    var panelWidth = panelRect.right - panelRect.left;
-                    if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                        // Reposition, because the panel is overflowing
-                        dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-                    }
-                } else {
-                    console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-                }
-            } else if(target == "dfn-panel") {
-                // Switch it to "activated" state, which pins it.
-                el.classList.add("activated");
-                el.style.left = null;
-                el.style.top = null;
-            }
-
+document.body.addEventListener("click", function(e) {
+    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
+    // Find the dfn element or panel, if any, that was clicked on.
+    var el = e.target;
+    var target;
+    var hitALink = false;
+    while(el.parentElement) {
+        if(el.tagName == "A") {
+            // Clicking on a link in a <dfn> shouldn't summon the panel
+            hitALink = true;
+        }
+        if(el.classList.contains("dfn-paneled")) {
+            target = "dfn";
+            break;
+        }
+        if(el.classList.contains("dfn-panel")) {
+            target = "dfn-panel";
+            break;
+        }
+        el = el.parentElement;
+    }
+    if(target != "dfn-panel") {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
+            el.classList.remove("on");
+            el.classList.remove("activated");
         });
-        </script>
+    }
+    if(target == "dfn" && !hitALink) {
+        // open the panel
+        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
+        if(dfnPanel) {
+            dfnPanel.classList.add("on");
+            var rect = el.getBoundingClientRect();
+            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
+            dfnPanel.style.top = window.scrollY + rect.top + "px";
+            var panelRect = dfnPanel.getBoundingClientRect();
+            var panelWidth = panelRect.right - panelRect.left;
+            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
+                // Reposition, because the panel is overflowing
+                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
+            }
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
+        }
+    } else if(target == "dfn-panel") {
+        // Switch it to "activated" state, which pins it.
+        el.classList.add("activated");
+        el.style.left = null;
+        el.style.top = null;
+    }
+
+});
+</script>


### PR DESCRIPTION
Fixes part of w3c/sensors#378


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Honry/proximity/pull/36.html" title="Last updated on Jan 28, 2019, 7:49 AM UTC (a7ee021)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/proximity/36/41e9f04...Honry:a7ee021.html" title="Last updated on Jan 28, 2019, 7:49 AM UTC (a7ee021)">Diff</a>