### PR TITLE
chore(ci): fix W3C_BUILD_OVERRIDE value

### DIFF
--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -14,12 +14,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: w3c/spec-prod@v2
+      - uses: w3c/spec-prod@test-63
         with:
           GH_PAGES_BRANCH: gh-pages
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
-          # Replace following with appropriate value. See options.md for details.
           W3C_WG_DECISION_URL: https://www.w3.org/2021/04/07-dap-minutes.html#r01
           W3C_BUILD_OVERRIDE: |
-            specStatus: WD
-            shortName: proximity
+            status: WD
+            shortame: proximity

--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -21,4 +21,4 @@ jobs:
           W3C_WG_DECISION_URL: https://www.w3.org/2021/04/07-dap-minutes.html#r01
           W3C_BUILD_OVERRIDE: |
             status: WD
-            shortame: proximity
+            shortname: proximity


### PR DESCRIPTION
`w3c/spec-prod` currently only accepts toolchain specific config overrides. See https://github.com/w3c/spec-prod/issues/57