### PR TITLE
Chore: update the SoTD

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -15,9 +15,9 @@ Abstract:
 Status Text:
   The Devices and Sensors Working Group will perform a round of self-review and
   revisions on the security and privacy aspects of the API before
-  requesting horizontal review. Existing security and privacy issues can
-  be found <a
-  href="https://www.w3.org/PM/horizontal/review.html?shortname=proximity-sensor">here</a>.
+  requesting horizontal review. Existing <a
+  href="https://www.w3.org/PM/horizontal/review.html?shortname=proximity-sensor">security
+  and privacy issues</a> are available.
 Version History: https://github.com/w3c/proximity/commits/main/index.bs
 !Bug Reports: <a href="https://www.github.com/w3c/proximity/issues/new">via the w3c/proximity repository on GitHub</a>
 Indent: 2


### PR DESCRIPTION
Tweak the link text so that it's easier for visually-impaired users to use their screen readers to scan for links.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/proximity/pull/51.html" title="Last updated on Aug 17, 2021, 6:54 AM UTC (3d15dc6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/proximity/51/38858d9...3d15dc6.html" title="Last updated on Aug 17, 2021, 6:54 AM UTC (3d15dc6)">Diff</a>