### PR TITLE
Make default allowlist normative

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -111,6 +111,10 @@ The <dfn>Proximity Sensor</dfn> <a>sensor type</a>'s associated {{Sensor}} subcl
 The <a>Proximity Sensor</a> has a <a>default sensor</a>,
 which is the device's main proximity detector.
 
+The <a>Proximity Sensor</a> has an associated [=sensor permission name=], which is <a for="PermissionName" enum-value>"proximity"</a>.
+
+The <a>Proximity Sensor</a> is a [=policy-controlled feature=] identified by the string "proximity-sensor". Its [=default allowlist=] is `'self'`.
+
 A [=latest reading=] for a {{Sensor}} of <a>Proximity Sensor</a> <a>sensor type</a> includes three [=map/entries=]
 whose [=map/keys=] are "distance", "max", "near" and whose [=map/values=] contain [=distance=],
 [=max=] and [=near=] values.


### PR DESCRIPTION
Add sensor permission name


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/proximity/pull/52.html" title="Last updated on Sep 1, 2021, 3:23 PM UTC (82c46a8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/proximity/52/a354e4b...82c46a8.html" title="Last updated on Sep 1, 2021, 3:23 PM UTC (82c46a8)">Diff</a>