### PR TITLE
Remove bikeshed custom anchor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -40,7 +40,6 @@ urlPrefix: https://w3c.github.io/sensors; spec: GENERIC-SENSOR
     text: initialize a sensor object; url: initialize-a-sensor-object
     text: sensor type
     text: check sensor policy-controlled features; url: check-sensor-policy-controlled-features
-    text: sensor readings; url: sensor-readings
     text: fingerprinting; url: device-fingerprinting
     text: user identifying; url: user-identifying
     text: mitigation strategies; url: mitigation-strategies


### PR DESCRIPTION
Fixed by https://github.com/w3c/sensors/pull/456

I guess we want to remove this custom plural anchor now to keep the spec tidy?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/proximity/pull/55.html" title="Last updated on Jan 27, 2023, 2:23 PM UTC (39cc118)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/proximity/55/0bb2c94...39cc118.html" title="Last updated on Jan 27, 2023, 2:23 PM UTC (39cc118)">Diff</a>