### PR TITLE
Rewrite Automation section after w3c/sensors#470

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -217,15 +217,15 @@ The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/e
 
     1.  Let |reading| be a new [=sensor reading=].
     1.  Let |keys| be the [=/list=] « "`distance`", "`max`" ».
-    1.  [=map/For each=] |keys| of [=/list=]
-        1.  Let |value| be the result of [=parse single-value number reading=] with |parameters| and |keys|.
+    1.  [=list/For each=] |key| of |keys|
+        1.  Let |value| be the result of [=parse single-value number reading=] with |parameters| and |key|.
             1.  If |value| is **undefined**.
                 1.  Return **undefined**.
         1.  [=map/Set=] |reading|[|keys|] to |value|[|keys|].
     1.  Let |near| be the result of invoking [=get a property=] from |parameters| with "near".
         1. If |near|'s type is not Boolean
             1.  Return **undefined**.
-        1.  [=map/Set=] reading["near"] to |near|.
+        1.  [=map/Set=] |reading|["near"] to |near|.
     1.  Return |reading|.
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -43,9 +43,6 @@ urlPrefix: https://w3c.github.io/sensors; spec: GENERIC-SENSOR
     text: fingerprinting; url: device-fingerprinting
     text: user identifying; url: user-identifying
     text: mitigation strategies; url: mitigation-strategies
-    text: automation
-    text: mock sensor type
-    text: mock sensor reading values
 </pre>
 <pre class="link-defaults">
 spec:infra;
@@ -199,23 +196,30 @@ Abstract Operations {#abstract-operations}
 
 Automation {#automation}
 ==========
-This section extends the [=automation=] section defined in the Generic Sensor API [[GENERIC-SENSOR]]
-to provide mocking information about the proximity level for the purposes of
-testing a user agent's implementation of {{ProximitySensor}} API.
 
-<h3 id="mock-proximity-sensor-type">Mock Sensor Type</h3>
+This section extends [[GENERIC-SENSOR#automation]] by providing [=Proximity Sensor=]-specific virtual sensor metadata.
 
-The {{ProximitySensor}} class has an associated [=mock sensor type=] which is
-<a for="MockSensorType" enum-value>"proximity"</a>, its [=mock sensor reading values=]
-dictionary is defined as follows:
+The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
+: [=map/key=]
+:: "`proximity`"
+: [=map/value=]
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Proximity Sensor=] and [=reading parsing algorithm=] is [=proximity reading parsing algorithm=].
 
-<pre class="idl">
-  dictionary ProximityReadingValues {
-    required double? distance;
-    required double? max;
-    required boolean? near;
-  };
-</pre>
+<h3 dfn>Proximity reading parsing algorithm</h3>
+<div algorithm="proximity reading parsing algorithm">
+    : input
+    :: |parameters|, a JSON {{Object}}
+    : output
+    :: A [=sensor reading=] or **undefined**
+
+    1.  Let |reading| be a new [=sensor reading=].
+    1.  Let |value| be a new [=sensor reading=].
+    1. Let |key| be the [=/list=] « "`distance`", "`max`", "`near`" ».
+    1.  [=map/For each=] |key| → let |value| be the result of [=parse single-value number reading=] with |parameters| and |key|.
+        1.  If |value| is "undefined".
+            1.  Return "undefined".
+        1.  [=map/Set=] |reading|[|key|] to |value|.
+    1.  Return |reading|.
 
 Limitations of Proximity Sensors {#limitations-proximity-sensors}
 ========================

--- a/index.bs
+++ b/index.bs
@@ -43,6 +43,9 @@ urlPrefix: https://w3c.github.io/sensors; spec: GENERIC-SENSOR
     text: fingerprinting; url: device-fingerprinting
     text: user identifying; url: user-identifying
     text: mitigation strategies; url: mitigation-strategies
+urlPrefix: https://w3c.github.io/webdriver/; spec: WEBDRIVER2
+  type: dfn
+    text: get a property; url: dfn-getting-properties
 </pre>
 <pre class="link-defaults">
 spec:infra;
@@ -203,7 +206,7 @@ The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/e
 : [=map/key=]
 :: "`proximity`"
 : [=map/value=]
-:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Proximity Sensor=] and [=reading parsing algorithm=] is [=proximity reading parsing algorithm=].
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Proximity Sensor=] and [=reading parsing algorithm=] is the [=proximity reading parsing algorithm=].
 
 <h3 dfn>Proximity reading parsing algorithm</h3>
 <div algorithm="proximity reading parsing algorithm">
@@ -213,13 +216,18 @@ The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/e
     :: A [=sensor reading=] or **undefined**
 
     1.  Let |reading| be a new [=sensor reading=].
-    1.  Let |value| be a new [=sensor reading=].
-    1. Let |key| be the [=/list=] « "`distance`", "`max`", "`near`" ».
-    1.  [=map/For each=] |key| → let |value| be the result of [=parse single-value number reading=] with |parameters| and |key|.
-        1.  If |value| is "undefined".
-            1.  Return "undefined".
-        1.  [=map/Set=] |reading|[|key|] to |value|.
+    1.  Let |keys| be the [=/list=] « "`distance`", "`max`" ».
+    1.  [=map/For each=] |keys| of [=/list=]
+        1.  Let |value| be the result of [=parse single-value number reading=] with |parameters| and |keys|.
+            1.  If |value| is **undefined**.
+                1.  Return **undefined**.
+        1.  [=map/Set=] |reading|[|keys|] to |value|[|keys|].
+    1.  Let |near| be the result of invoking [=get a property=] from |parameters| with "near".
+        1. If |near|'s type is not Boolean
+            1.  Return **undefined**.
+        1.  [=map/Set=] reading["near"] to |near|.
     1.  Return |reading|.
+</div>
 
 Limitations of Proximity Sensors {#limitations-proximity-sensors}
 ========================

--- a/index.bs
+++ b/index.bs
@@ -221,7 +221,7 @@ The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/e
         1.  Let |value| be the result of invoking [=parse single-value number reading=] with |parameters| and |key|.
             1.  If |value| is **undefined**.
                 1.  Return **undefined**.
-        1.  [=map/Set=] |reading|[|keys|] to |value|[|keys|].
+        1.  [=map/Set=] |reading|[|key|] to |value|[|key|].
     1.  Let |near| be the result of invoking [=get a property=] from |parameters| with "`near`".
         1. If |near|'s type is not Boolean
             1.  Return **undefined**.

--- a/index.bs
+++ b/index.bs
@@ -218,14 +218,14 @@ The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/e
     1.  Let |reading| be a new [=sensor reading=].
     1.  Let |keys| be the [=/list=] « "`distance`", "`max`" ».
     1.  [=list/For each=] |key| of |keys|
-        1.  Let |value| be the result of [=parse single-value number reading=] with |parameters| and |key|.
+        1.  Let |value| be the result of invoking [=parse single-value number reading=] with |parameters| and |key|.
             1.  If |value| is **undefined**.
                 1.  Return **undefined**.
         1.  [=map/Set=] |reading|[|keys|] to |value|[|keys|].
-    1.  Let |near| be the result of invoking [=get a property=] from |parameters| with "near".
+    1.  Let |near| be the result of invoking [=get a property=] from |parameters| with "`near`".
         1. If |near|'s type is not Boolean
             1.  Return **undefined**.
-        1.  [=map/Set=] |reading|["near"] to |near|.
+        1.  [=map/Set=] |reading|["`near`"] to |near|.
     1.  Return |reading|.
 </div>
 


### PR DESCRIPTION
The Automation section in the Generic Sensor API specification was rewritten and several terms and concepts have changed.

This commit adapts the Proximity Sensor spec to the changes:

- Remove references to "mock sensor type", "mock sensor reading values" and the "MockSensorType" enum.
- Define an entry in the per-type virtual sensor metadata map whose key is what used to be the "proximity" entry in MockSensorType and an appropriate virtual sensor metadata entry.

This is enough to integrate properly with the Generic Sensor spec and allow Proximity virtual sensors to be created and used.

Fixes #56.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JuhaVainio/proximity/pull/57.html" title="Last updated on Oct 26, 2023, 7:46 AM UTC (d50353b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/proximity/57/67c242f...JuhaVainio:d50353b.html" title="Last updated on Oct 26, 2023, 7:46 AM UTC (d50353b)">Diff</a>