### PR TITLE
Clean up Model section, export permission and policy-controlled feature name

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -102,22 +102,30 @@ To mitigate these, user agents should use one or both of the following [=mitigat
 These mitigation strategies complement the [=mitigation strategies|generic mitigations=]
 defined in the Generic Sensor API [[!GENERIC-SENSOR]].
 
+Permissions Policy integration {#permissions-policy-integration}
+==============================
+
+This specification defines a [=policy-controlled feature=] identified by the string "<code><dfn data-lt="proximity-sensor-feature" export>proximity-sensor</dfn></code>". Its [=default allowlist=] is "`self`".
+
 Model {#model}
 =====
 
-The <dfn>Proximity Sensor</dfn> <a>sensor type</a>'s associated {{Sensor}} subclass is the {{ProximitySensor}} class.
+The <dfn id="proximity-sensor-sensor-type">Proximity Sensor</dfn> <a>sensor type</a> has the following associated data:
 
-The <a>Proximity Sensor</a> has a <a>default sensor</a>,
-which is the device's main proximity detector.
-
-The <a>Proximity Sensor</a> has an associated [=sensor permission name=], which is <a for="PermissionName" enum-value>"proximity"</a>.
-
-The <a>Proximity Sensor</a> is a [=policy-controlled feature=] identified by the string "proximity-sensor". Its [=default allowlist=] is `'self'`.
+ : [=Extension sensor interface=]
+ :: {{ProximitySensor}}
+ : [=Sensor permission names=]
+ :: "<code><dfn permission export>proximity</dfn></code>"
+ : [=Sensor feature names=]
+ :: "[=proximity-sensor-feature|proximity-sensor=]"
+ : [=powerful feature/Permission revocation algorithm=]
+ :: Invoke the [=generic sensor permission revocation algorithm=] with "<code><a permission>proximity</a></code>".
+ : [=Default sensor=]
+ :: The device's main proximity detector.
 
 A [=latest reading=] for a {{Sensor}} of <a>Proximity Sensor</a> <a>sensor type</a> includes three [=map/entries=]
 whose [=map/keys=] are "distance", "max", "near" and whose [=map/values=] contain [=distance=],
 [=max=] and [=near=] values.
-
 
 The <dfn>distance</dfn> is a value that represents the distance between a device and
 the closest visible surface of the physical object within the <dfn>sensing range</dfn>.


### PR DESCRIPTION
* Move the permissions-policy text to a separate section for clarity.
* Stop saying "Proximity Sensor a policy-controlled feature" because it does
  not make much sense. The most common way to list features is by saying
  something like "this spec defines a feature identifed by the string
  'foo'". In our case, that string is "proximity-sensor".
* Define and export the feature identifier above.
* Explicitly list all data associated with the spec's sensor type using a
  definition list instead of a very long paragraph.
* Similarly to w3c/accelerometer#67, define and export the "gyroscope"
  permission so that we can eventually link to the permission name from
  https://w3c.github.io/permissions-registry/


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/proximity/pull/58.html" title="Last updated on Oct 26, 2023, 9:42 AM UTC (3963f69)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/proximity/58/1be5160...rakuco:3963f69.html" title="Last updated on Oct 26, 2023, 9:42 AM UTC (3963f69)">Diff</a>