### PR TITLE
Adapt to virtual sensor changes in w3c/sensors#475

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -122,6 +122,8 @@ The <dfn id="proximity-sensor-sensor-type">Proximity Sensor</dfn> <a>sensor type
  :: Invoke the [=generic sensor permission revocation algorithm=] with "<code><a permission>proximity</a></code>".
  : [=Default sensor=]
  :: The device's main proximity detector.
+ : [=Virtual sensor type=]
+ :: "<code><dfn data-lt="proximity virtual sensor type">proximity</dfn></code>"
 
 A [=latest reading=] for a {{Sensor}} of <a>Proximity Sensor</a> <a>sensor type</a> includes three [=map/entries=]
 whose [=map/keys=] are "distance", "max", "near" and whose [=map/values=] contain [=distance=],
@@ -212,9 +214,9 @@ This section extends [[GENERIC-SENSOR#automation]] by providing [=Proximity Sens
 
 The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
 : [=map/key=]
-:: "`proximity`"
+:: "<code>[=proximity virtual sensor type|proximity=]</code>"
 : [=map/value=]
-:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Proximity Sensor=] and [=reading parsing algorithm=] is the [=proximity reading parsing algorithm=].
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/reading parsing algorithm=] is the [=proximity reading parsing algorithm=].
 
 <h3 dfn>Proximity reading parsing algorithm</h3>
 <div algorithm="proximity reading parsing algorithm">


### PR DESCRIPTION
w3c/sensors#475 removed the "virtual sensor type" item from the "virtual
sensor metadata" struct and turned it into a string that is referenced from
the automation bits as well as (optionally) defined by a sensor type.

Adapt to it here by removing mentions of `[=virtual sensor metadata/virtual
sensor type=]` from the spec and adding virtual sensor types to each sensor
type defined here.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/proximity/pull/59.html" title="Last updated on Nov 22, 2023, 4:10 PM UTC (147f420)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/proximity/59/576057f...rakuco:147f420.html" title="Last updated on Nov 22, 2023, 4:10 PM UTC (147f420)">Diff</a>