### PR TITLE
Add SotD implementation status advisement

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12,12 +12,18 @@ Group: dap
 Abstract:
   This specification defines a concrete sensor interface to monitor
   the presence of nearby physical objects without physical contact.
-Status Text:
+Status Text: <div class="advisement">
+  This specification has not shipped in any major browser engine.
+  Implementer standards positions:
+  <a href="https://github.com/mozilla/standards-positions/issues/35">Mozilla</a>.
+  No WebKit standards position has been filed.
+  </div>
   The Devices and Sensors Working Group will perform a round of self-review and
   revisions on the security and privacy aspects of the API before
   requesting horizontal review. Existing <a
   href="https://www.w3.org/PM/horizontal/review.html?shortname=proximity-sensor">security
   and privacy issues</a> are available.
+
 Version History: https://github.com/w3c/proximity/commits/main/index.bs
 !Bug Reports: <a href="https://www.github.com/w3c/proximity/issues/new">via the w3c/proximity repository on GitHub</a>
 Indent: 2


### PR DESCRIPTION
Adds a `.advisement` box to the Status of This Document section to signal implementation status to developers at a glance.

Per TAG requirement ([w3ctag/design-reviews#1187](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-3889788860)):

> At a minimum, each document's support level should be in its SotD section, but ideally the WG would find a way to ensure that developers reading a specification can tell at a glance which kind of document they're reading.

All implementation status claims are verified against MDN BCD. Standards position URLs are verified against the live issues.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcoscaceres/proximity/pull/62.html" title="Last updated on Mar 31, 2026, 4:56 AM UTC (f83cdf8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/proximity/62/453a6b6...marcoscaceres:f83cdf8.html" title="Last updated on Mar 31, 2026, 4:56 AM UTC (f83cdf8)">Diff</a>